### PR TITLE
PHP 8.2 DateTimeImmutable compatibility fix

### DIFF
--- a/src/Misc/Factory/DateTimeFactory.php
+++ b/src/Misc/Factory/DateTimeFactory.php
@@ -54,7 +54,7 @@ class DateTimeFactory
     {
         $errors = DateTimeImmutable::getLastErrors();
         if ($errors === false) {
-            return true;
+            return false;
         }
 
         return $errors['warning_count'] > 0 || $errors['error_count'] > 0;


### PR DESCRIPTION
According to: https://www.php.net/manual/en/datetimeimmutable.getlasterrors.php if `DateTimeImmutable::getLastErrors()` returns `false` there is no errors at all. In PHP 8.2 `false` is returned when no errors (unlike version <=8.1 where an array is always returned), which leads to the entire library not working properly.